### PR TITLE
Fixed port number for Syncthing v0.11

### DIFF
--- a/main.go
+++ b/main.go
@@ -407,7 +407,7 @@ func updateStatus() {
 
 func main() {
 
-	url := flag.String("target", "http://localhost:8080", "Target Syncthing instance")
+	url := flag.String("target", "http://localhost:8384", "Target Syncthing instance")
 	user := flag.String("u", "", "User")
 	pw := flag.String("p", "", "Password")
 	insecure := flag.Bool("i", false, "skip verification of SSL certificate")


### PR DESCRIPTION
Updated the port number to be compatible to SyncThing 0.11
which is now using 8384 instead of 8080.